### PR TITLE
Image Upload and Persistence Support

### DIFF
--- a/controllers/base.go
+++ b/controllers/base.go
@@ -28,22 +28,28 @@ var (
 	baseName = "base"
 	base     = tmplDir + baseName + ".html"
 
+	templateHelpers = template.FuncMap{
+		"evenlyDivisible": func(a, b int) bool {
+			return (a % b) == 0
+		},
+	}
+
 	templates = map[string]*template.Template{
-		"dormant/home":        template.Must(template.ParseFiles(base, dormDir+"home.html")),
-		"dormant/about":       template.Must(template.ParseFiles(base, dormDir+"about.html")),
-		"dormant/faqs":        template.Must(template.ParseFiles(base, dormDir+"faqs.html")),
-		"dormant/feedback":    template.Must(template.ParseFiles(base, dormDir+"feedback.html")),
-		"dormant/help":        template.Must(template.ParseFiles(base, dormDir+"help.html")),
-		"dormant/unsupported": template.Must(template.ParseFiles(base, dormDir+"unsupported.html")),
-		"dormant/error":       template.Must(template.ParseFiles(base, dormDir+"error.html")),
+		"dormant/home":        template.Must(template.New("").Funcs(templateHelpers).ParseFiles(base, simListFrag, dormDir+"home.html")),
+		"dormant/about":       template.Must(template.New("").Funcs(templateHelpers).ParseFiles(base, dormDir+"about.html")),
+		"dormant/faqs":        template.Must(template.New("").Funcs(templateHelpers).ParseFiles(base, dormDir+"faqs.html")),
+		"dormant/feedback":    template.Must(template.New("").Funcs(templateHelpers).ParseFiles(base, dormDir+"feedback.html")),
+		"dormant/help":        template.Must(template.New("").Funcs(templateHelpers).ParseFiles(base, dormDir+"help.html")),
+		"dormant/unsupported": template.Must(template.New("").Funcs(templateHelpers).ParseFiles(base, dormDir+"unsupported.html")),
+		"dormant/error":       template.Must(template.New("").Funcs(templateHelpers).ParseFiles(base, dormDir+"error.html")),
 
-		"simulator/browse":     template.Must(template.ParseFiles(base, simListFrag, simDir+"browse.html")),
-		"simulator/mobile":     template.Must(template.ParseFiles(base, comFrag, simDir+"mobile.html")),
-		"simulator/kinematics": template.Must(template.ParseFiles(base, comFrag, simFrag, simDir+"kinematics.html")),
+		"simulator/browse":     template.Must(template.New("").Funcs(templateHelpers).ParseFiles(base, simListFrag, simDir+"browse.html")),
+		"simulator/mobile":     template.Must(template.New("").Funcs(templateHelpers).ParseFiles(base, comFrag, simDir+"mobile.html")),
+		"simulator/kinematics": template.Must(template.New("").Funcs(templateHelpers).ParseFiles(base, comFrag, simFrag, simDir+"kinematics.html")),
 
-		"user/simulations":  template.Must(template.ParseFiles(base, simListFrag, userDir+"simulations.html")),
-		"user/interactions": template.Must(template.ParseFiles(base, simListFrag, userDir+"interactions.html")),
-		"user/profile":      template.Must(template.ParseFiles(base, simListFrag, userDir+"profile.html")),
+		"user/simulations":  template.Must(template.New("").Funcs(templateHelpers).ParseFiles(base, simListFrag, userDir+"simulations.html")),
+		"user/interactions": template.Must(template.New("").Funcs(templateHelpers).ParseFiles(base, simListFrag, userDir+"interactions.html")),
+		"user/profile":      template.Must(template.New("").Funcs(templateHelpers).ParseFiles(base, simListFrag, userDir+"profile.html")),
 
 		"test/kinematics": template.Must(template.ParseFiles(testDir + "KinematicsRunner.html")),
 	}

--- a/controllers/simulator/simulator.go
+++ b/controllers/simulator/simulator.go
@@ -2,10 +2,14 @@ package simulator
 
 import (
 	"appengine"
+	"appengine/blobstore"
 	"appengine/datastore"
+	appengineImage "appengine/image"
+	"bytes"
 	"controllers"
 	"controllers/api"
 	"controllers/utils"
+	"io"
 	"lib/gorilla/mux"
 	"models"
 	"net/http"
@@ -45,18 +49,26 @@ func newGenericHandler(w http.ResponseWriter, r *http.Request, simType string, t
 
 		key, keyName := utils.GenerateUniqueKey(ctx, "Simulation", user, nil)
 
+		// Get all of the form values and blob image from the post
+		blobs, formValues, err := blobstore.ParseUpload(r)
+		if err != nil {
+			controllers.ErrorHandler(w, r, "Bad blobstore form parse: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
 		// Create the simulation object
 		creationTime := time.Now()
 		simulation = models.Simulation{
 			KeyName:       keyName,
-			Name:          r.FormValue("Name"),
-			Simulator:     r.FormValue("Contents"),
+			Name:          formValues["Name"][0],
+			Simulator:     formValues["Contents"][0],
 			Type:          simType,
-			Description:   r.FormValue("Description"),
+			Description:   formValues["Description"][0],
 			CreationDate:  creationTime,
 			UpdatedDate:   creationTime,
-			IsPrivate:     utils.StringToBool(r.FormValue("IsPrivate")),
+			IsPrivate:     utils.StringToBool(formValues["IsPrivate"][0]),
 			AuthorKeyName: user.KeyName,
+			ImageBlobKey:  blobs["Thumbnail"][0].BlobKey,
 		}
 
 		// Put the simulation in the datastore
@@ -68,17 +80,30 @@ func newGenericHandler(w http.ResponseWriter, r *http.Request, simType string, t
 		}
 
 		pagePath := r.URL.Path + "/" + simulation.KeyName
+		// an AJAX Request would prevent a redirect.
+		// http.Redirect(w, r, pagePath, http.StatusFound)
 
-		// an AJAX Request would prevent a redirect..
-		http.Redirect(w, r, pagePath, http.StatusFound)
+		// The logic that allows posting an image generated from a canvas as FormData
+		// requires that the POST is asynchronous? So post back what the redirect should be
+		pagePathBuff := bytes.NewBufferString(pagePath)
+		io.Copy(w, pagePathBuff)
+		return
+	}
+
+	// The autosaved thumbnail images need to be POSTed to specific appengine blobstore "action" paths.
+	// Have to specify a path to return to after the post succeeds
+	imageUploadUrl, err := blobstore.UploadURL(ctx, r.URL.Path, nil)
+	if err != nil {
+		controllers.ErrorHandler(w, r, "Could not generate blobstore upload: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	// If it's a new simulation, you're the owner
 	data := map[string]interface{}{
-		"simulation": simulation,
-		"new":        true,
-		"isOwner":    true,
+		"simulation":     simulation,
+		"imageUploadUrl": imageUploadUrl.Path,
+		"new":            true,
+		"isOwner":        true,
 	}
 
 	controllers.BaseHandler(w, r, template, data)
@@ -108,10 +133,32 @@ func editGenericHandler(w http.ResponseWriter, r *http.Request, simType string, 
 
 	isOwner := utils.IsOwner(simulation.AuthorKeyName, ctx)
 	if r.Method == "POST" && isOwner {
-		simulation.Name = r.FormValue("Name")
-		simulation.Simulator = r.FormValue("Contents")
-		simulation.Description = r.FormValue("Description")
-		simulation.IsPrivate = utils.StringToBool(r.FormValue("IsPrivate"))
+		// Get all of the form values and blob image from the post
+		blobs, formValues, err := blobstore.ParseUpload(r)
+		if err != nil {
+			api.ApiErrorResponse(w, "Bad blobstore form parse: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// Delete the url displaying the old thumbnail image in the blobstore
+		err = appengineImage.DeleteServingURL(ctx, simulation.ImageBlobKey)
+		if err != nil {
+			api.ApiErrorResponse(w, "Can't delete the image's serving URL: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		// Delete the old thumbnail image in the blobstore
+		err = blobstore.Delete(ctx, simulation.ImageBlobKey)
+		if err != nil {
+			api.ApiErrorResponse(w, "Can't delete the blobstore image: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// Update the simulation with new values, including the new thumbnail image key
+		simulation.Name = formValues["Name"][0]
+		simulation.Simulator = formValues["Contents"][0]
+		simulation.Description = formValues["Description"][0]
+		simulation.IsPrivate = utils.StringToBool(formValues["IsPrivate"][0])
+		simulation.ImageBlobKey = blobs["Thumbnail"][0].BlobKey
 		simulation.UpdatedDate = time.Now()
 
 		// Put the simulation in the datastore
@@ -129,6 +176,19 @@ func editGenericHandler(w http.ResponseWriter, r *http.Request, simType string, 
 	}
 
 	if r.Method == "DELETE" && isOwner {
+		// Delete the url displaying the old thumbnail image in the blobstore
+		err = appengineImage.DeleteServingURL(ctx, simulation.ImageBlobKey)
+		if err != nil {
+			api.ApiErrorResponse(w, "Can't delete the image's serving URL: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		// Delete the old thumbnail image in the blobstore
+		err = blobstore.Delete(ctx, simulation.ImageBlobKey)
+		if err != nil {
+			api.ApiErrorResponse(w, "Can't delete the blobstore image: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
 		// Delete the simulation in the datastore
 		err = datastore.Delete(ctx, simulationKey)
 
@@ -141,10 +201,19 @@ func editGenericHandler(w http.ResponseWriter, r *http.Request, simType string, 
 		return
 	}
 
+	// The autosaved thumbnail images need to be POSTed to specific appengine blobstore "action" paths.
+	// Have to specify a path to return to after the post succeeds
+	imageUploadUrl, err := blobstore.UploadURL(ctx, r.URL.Path, nil)
+	if err != nil {
+		controllers.ErrorHandler(w, r, "Could not generate blobstore upload: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	data := map[string]interface{}{
-		"simulation": simulationData,
-		"new":        false,
-		"isOwner":    isOwner,
+		"simulation":     simulationData,
+		"imageUploadUrl": imageUploadUrl.Path,
+		"new":            false,
+		"isOwner":        isOwner,
 	}
 
 	controllers.BaseHandler(w, r, template, data)

--- a/controllers/simulator/simulator.go
+++ b/controllers/simulator/simulator.go
@@ -146,6 +146,7 @@ func editGenericHandler(w http.ResponseWriter, r *http.Request, simType string, 
 			api.ApiErrorResponse(w, "Can't delete the image's serving URL: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
+
 		// Delete the old thumbnail image in the blobstore
 		err = blobstore.Delete(ctx, simulation.ImageBlobKey)
 		if err != nil {
@@ -182,6 +183,7 @@ func editGenericHandler(w http.ResponseWriter, r *http.Request, simType string, 
 			api.ApiErrorResponse(w, "Can't delete the image's serving URL: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
+
 		// Delete the old thumbnail image in the blobstore
 		err = blobstore.Delete(ctx, simulation.ImageBlobKey)
 		if err != nil {

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"appengine"
 	"appengine/datastore"
+	appengineImage "appengine/image"
 	appengineUser "appengine/user"
 	"errors"
 	"log"
@@ -65,8 +66,13 @@ func BuildSimulationData(ctx appengine.Context, simObj models.Simulation, simKey
 	var author models.User
 	var sim models.SimulationData
 
+	thumbnailImage, err := appengineImage.ServingURL(ctx, simObj.ImageBlobKey, nil)
+	if err != nil {
+		return sim, err
+	}
+
 	authorKey := datastore.NewKey(ctx, "User", simObj.AuthorKeyName, 0, nil)
-	err := datastore.Get(ctx, authorKey, &author)
+	err = datastore.Get(ctx, authorKey, &author)
 	if err != nil {
 		return sim, err
 	}
@@ -89,6 +95,7 @@ func BuildSimulationData(ctx appengine.Context, simObj models.Simulation, simKey
 	sim.Description = simObj.Description
 	sim.CreationDate = simObj.CreationDate
 	sim.UpdatedDate = simObj.UpdatedDate
+	sim.ImageSrcUrl = thumbnailImage.Path
 	sim.IsPrivate = simObj.IsPrivate
 	sim.AuthorName = author.DisplayName
 	sim.AuthorID = author.KeyName

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -146,6 +146,12 @@ func BuildCommentData(ctx appengine.Context, comObj models.Comment, commentKey *
 		return com, err
 	}
 
+	var profileImageSrc string
+	profileImage, err := appengineImage.ServingURL(ctx, author.ImageBlobKey, nil)
+	if err == nil {
+		profileImageSrc = profileImage.Path
+	}
+
 	err = datastore.Get(ctx, commentKey.Parent(), &sim)
 	if err != nil {
 		return com, err
@@ -161,6 +167,7 @@ func BuildCommentData(ctx appengine.Context, comObj models.Comment, commentKey *
 	com.CreationDate = comObj.CreationDate
 	com.AuthorName = author.DisplayName
 	com.AuthorID = author.KeyName
+	com.AuthorImageSrcUrl = profileImageSrc
 	com.SimulationName = sim.Name
 	com.SimulationID = sim.KeyName
 	com.SimulationType = sim.Type

--- a/models/comment.go
+++ b/models/comment.go
@@ -21,9 +21,10 @@ type Comment struct {
 // All data necessary for nicely displaying a comment in a view
 type CommentData struct {
 	Comment
-	AuthorName     string
-	AuthorID       string
-	SimulationName string
-	SimulationID   string
-	SimulationType string
+	AuthorName        string
+	AuthorID          string
+	AuthorImageSrcUrl string
+	SimulationName    string
+	SimulationID      string
+	SimulationType    string
 }

--- a/models/simulation.go
+++ b/models/simulation.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"appengine"
 	"time"
 )
 
@@ -16,6 +17,7 @@ type Simulation struct {
 	UpdatedDate   time.Time
 	IsPrivate     bool
 	AuthorKeyName string // Used to get Author Key
+	ImageBlobKey  appengine.BlobKey
 	// Ratings by descendant
 	// Comments by descendant
 }
@@ -27,6 +29,7 @@ type SimulationData struct {
 	AuthorName  string
 	AuthorID    string
 	RatingTotal int
+	ImageSrcUrl string
 }
 
 // ByRating implements sort.Interface for []SimulationData based on

--- a/models/user.go
+++ b/models/user.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"appengine"
 	"time"
 )
 
@@ -9,9 +10,10 @@ type User struct {
 	KeyName  string // UniqueID used to get Key
 	GoogleID string
 
-	DisplayName string
-	Interests   string
-	Email       string
-	Admin       bool
-	JoinDate    time.Time
+	DisplayName  string
+	Interests    string
+	Email        string
+	Admin        bool
+	JoinDate     time.Time
+	ImageBlobKey appengine.BlobKey
 }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -816,3 +816,8 @@ a#help-tooltips:hover {
   span.user-display-name {
     font-style: normal;
   }
+
+  .simulation-thumb-description {
+    border-top: 2px solid #000;
+    background: #eeeeee;
+  }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -521,12 +521,8 @@ input[type=checkbox] .lever::-webkit-slider-thumb {
 }
 
 /* Profile Page */
-#profile-pic-container {
-  height: 250px; 
-  width: 70%; 
-  border: dashed 1px grey; 
-  margin:auto; 
-  border-radius: 5px
+.empty-profile-image-container {
+  padding: 57px 0;
 }
 
 #profile-welcome-modal {

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -693,12 +693,13 @@ a#help-tooltips:hover {
   .card-list .card-panel .activator {
     position: absolute;
     right: 15px;
+    bottom: 15px;
     z-index: 1;
   }
 
   .card-list .card-quarter-width .card-content,
   .card-list .card-quarter-width .card-content {
-    font-size: 0.8em;
+    font-size: 1em;
     padding: 20px;
   }
 
@@ -714,6 +715,16 @@ a#help-tooltips:hover {
 
   .card-quarter-width {
     width: 23%;
+  }
+
+  .simulation-thumb {
+    background: #222222;
+  }
+
+  .simulation-thumb-description {
+    color: #ffffff;
+    background: #222222;
+    word-wrap: break-word;
   }
 
 /* color gradients used as accents */
@@ -811,9 +822,4 @@ a#help-tooltips:hover {
 /* user display name identifier */
   span.user-display-name {
     font-style: normal;
-  }
-
-  .simulation-thumb-description {
-    border-top: 2px solid #000;
-    background: #eeeeee;
   }

--- a/static/js/forms.js
+++ b/static/js/forms.js
@@ -25,8 +25,7 @@ $( document ).ready(function() {
 });
 
 
-// http://stackoverflow.com/questions/6850276/how-to-convert-dataurl-to-file-object-in-javascript
-function simulationFormPost(path, parameters) {
+function formPost(path, parameters, successMessage) {
   var fd = new FormData(document.forms[0]);
   var xhr = new XMLHttpRequest();
   xhr.open('POST', path);
@@ -36,7 +35,7 @@ function simulationFormPost(path, parameters) {
       if (xhr.readyState === xhr.DONE) {
         if (xhr.status === 200) {
           window.location = xhr.responseText; // Redirects to saved simulation link
-          successToast('Simulation saved successfully!');
+          successToast(successMessage);
         } else {
           failToast(xhr.responseText);
         }
@@ -46,9 +45,12 @@ function simulationFormPost(path, parameters) {
     xhr.onload = function() { // Show toasts
       if (xhr.readyState === xhr.DONE) {
         if (xhr.status === 200) {
-          $("#save-button").removeClass( "blue" )
-          $("#save-button").addClass( "green" )
-          successToast('Simulation saved successfully!');
+          if ($("#save-button").size() > 0) {
+            $("#save-button").removeClass( "blue" )
+            $("#save-button").addClass( "green" )
+          }
+          window.location.reload(); // Necessary to get new image save form "action" attribute
+          successToast(successMessage);
         } else {
           failToast(xhr.responseText);
         }
@@ -69,21 +71,21 @@ function simulationFormPost(path, parameters) {
 // if a new simulation it does NOT use ajax to allow
 // for a page redirect to simulator/{simulatorId}
 function saveSimulation(postURL){
-    if (!postURL) {
-      postURL = window.location.href;
-    }
+  if (!postURL) {
+    postURL = window.location.href;
+  }
 
-    simObject = [
-      {name: "Name",        value: $("#simulation-name").val(),                type: "text"},
-      {name: "Contents",    value: exportToJson(),                             type: "text"},
-      {name: "Description", value: $("#simulation-description").val(),         type: "text"},
-      {name: "IsPrivate",   value: $("#simulation-is-private").is(":checked"), type: "text"},
-      {name: "Thumbnail",   value: dataURItoBlob(canvasToImage()),             type: "file"},
-    ];
+  simObject = [
+    {name: "Name",        value: $("#simulation-name").val(),                type: "text"},
+    {name: "Contents",    value: exportToJson(),                             type: "text"},
+    {name: "Description", value: $("#simulation-description").val(),         type: "text"},
+    {name: "IsPrivate",   value: $("#simulation-is-private").is(":checked"), type: "text"},
+    {name: "Thumbnail",   value: dataURItoBlob(canvasToImage()),             type: "file"},
+  ];
 
-    simulationFormPost(postURL, simObject)
+  formPost(postURL, simObject, "Simulation saved successfully!");
 
-    losefocus();
+  losefocus();
 }
 
 function deleteSimulation(simUrl, redirectUrl, element) {
@@ -106,19 +108,43 @@ function deleteSimulation(simUrl, redirectUrl, element) {
   });
 }
 
-function saveUser() {
-    simObject = { DisplayName: $("#user-display-name").val(), Interests:  $("#user-interests").val()};
+function validateUserImageSelection() {
+  var uploadMessage = $('#image-upload-message')[0];
 
-    $.post(window.location.href, simObject)
-        .done(function() { 
-            // I believe 'done' is synonymous with 'success' here
-            $("#profile-save-button").removeClass( "blue" )
-            $("#profile-save-button").addClass( "green" )
-            successToast('User saved successfully!');
-        })
-        .fail(function(xhr, textStatus, errorThrown) {
-          failToast(xhr.responseText);
-        });
+  var imageFiles = document.getElementById("user-profile-image").files;
+  if (imageFiles && imageFiles[0].size < 500000) { // 500kB
+    uploadMessage.text = "Ready to save " + imageFiles[0].name + "!";
+  } else {
+    uploadMessage.text = "This image might be too large! The max file size is 500KB";
+  }
+}
+
+function saveUser(postURL) {
+  if (!postURL) {
+    postURL = window.location.href;
+  }
+
+  var imageFiles = document.getElementById("user-profile-image").files;
+  if (imageFiles && imageFiles[0]) {
+    if (imageFiles[0].size < 500000) { // 500KB
+      userObject = [
+        {name: "DisplayName",  value: $("#user-display-name").val(), type: "text"},
+        {name: "Interests",    value: $("#user-interests").val(),    type: "text"},
+        {name: "ProfileImage", value: imageFiles[0],                 type: "file"},
+      ];
+
+      formPost(postURL, userObject, "Information saved successfully!");
+    } else {
+      failToast("This image might be too large! The max file size is 500KB");
+    }
+  } else {
+    userObject = [
+      {name: "DisplayName",  value: $("#user-display-name").val(), type: "text"},
+      {name: "Interests",    value: $("#user-interests").val(),    type: "text"},
+    ];
+
+    formPost(postURL, userObject, "Information saved successfully!");
+  }
 }
 
 // Save new comment to the datastore
@@ -164,17 +190,33 @@ function refreshCommentsList() {
     if (json) {
       for (var i = 0; i < json.length; i++) {
         var comment = json[i];
-        result +=  "<div class='row'>";
-        result +=   "<div class='col s2'><a href='/user/" + comment.AuthorID + "'>";
-        result +=    "<i class='medium fa fa-user'></i>";
-        result +=    "<small>" + comment.AuthorName + "</small>";
-        result +=  "</a></div>";
-        result +=  "<div class='col s10 all-bubble-content' id='new-comment'>";
-        result +=    "<div class='row'>";
-        result +=      "<div class='all-point'></div>";
-        result +=      "<div class='col  s12'>";
-        result +=         "<p class=''>" +comment.Contents+"</p> ";
-        result +=      "</div></div></div></div>";
+        var displayName = 'Anonymous';
+        if (comment.AuthorName) {
+          displayName = comment.AuthorName;
+        }
+
+        var imgDisplay = "<i class='medium black-text fa fa-user'></i>";
+        if (comment.AuthorImageSrcUrl) {
+          imgDisplay = "<img src='" + comment.AuthorImageSrcUrl + "' class='responsive-img'>"
+        }
+
+        result += "<div class='col s12'>";
+        result +=   "<div class='row'>";
+        result +=     "<div class='card-panel valign-wrapper'>";
+        result +=       "<div class='col s3'>";
+        result +=         "<div class='center-align'>";
+        result +=           "<a href='/user/" + comment.AuthorID + "'>" + imgDisplay + "</a>";
+        result +=           "<a href='/user/" + comment.AuthorID + "'><small>" + displayName + "</small></a>";
+        result +=         "</div>";
+        result +=       "</div>";
+        result +=       "<div class='col s9'>";
+        result +=         "<span class='black-text'>";
+        result +=           comment.Contents
+        result +=         "</span>";
+        result +=       "</div>";
+        result +=     "</div>";
+        result +=   "</div>";
+        result += "</div>";
       }
     }
 
@@ -232,21 +274,6 @@ function isNewSim(){
   } else {
     return false;
   }
-}
-
-// Used when uploading a new profile picture on the profile page
-function readURL(input) {
-    if (input.files && input.files[0]) {
-        var reader = new FileReader();
-
-        reader.onload = function (e) {
-            $('#profile-pic')
-                .attr('src', e.target.result)
-        };
-
-        reader.readAsDataURL(input.files[0]);
-    }
-
 }
 
 function getfocus() {

--- a/static/js/simulator/base.js
+++ b/static/js/simulator/base.js
@@ -22,6 +22,75 @@ function exportToJson(){
   return JSON.stringify(json);
 }
 
+// Returns contents of a canvas as a jpeg based data url, with the specified
+// background color
+// http://www.mikechambers.com/blog/2011/01/31/setting-the-background-color-when-generating-images-from-canvas-todataurl
+function canvasToImage() {
+  // cache height and width
+  var canvas = Globals.world.renderer();
+  var context = canvas.ctx;
+  var w = canvas.width;
+  var h = canvas.height;
+
+  // get the current ImageData for the canvas.
+  var data = context.getImageData(0, 0, w, h);
+
+  // store the current globalCompositeOperation
+  var compositeOperation = context.globalCompositeOperation;
+
+  // set to draw behind current content
+  context.globalCompositeOperation = "destination-over";
+
+  // set background color
+  context.fillStyle = '#ffffff';
+
+  // draw background / rect on entire canvas
+  context.fillRect(0, 0, w, h);
+
+  // get the image data from the canvas
+  var imageData = canvas.el.toDataURL("image/jpeg", 0.5);
+
+  // clear the canvas
+  context.clearRect(0, 0, w, h);
+
+  // restore it with original / cached ImageData
+  context.putImageData(data, 0, 0);
+
+  // reset the globalCompositeOperation to what it was
+  context.globalCompositeOperation = compositeOperation;
+
+  // var head = 'data:image/jpeg;base64,';
+  // var imgFileSize = Math.round((imageData.length - head.length) * 3/4) ;
+  // console.log("generated image file size: " + imgFileSize);
+
+  // return the Base64 encoded data url string
+  return imageData;
+}
+
+// Turns the dataURI created by the canvas to an actual blob that is recognized
+// as a file to be uploaded in a form and saved to the blobstore
+// http://stackoverflow.com/questions/4998908/convert-data-uri-to-file-then-append-to-formdata
+function dataURItoBlob(dataURI) {
+  // convert base64/URLEncoded data component to raw binary data held in a string
+  var byteString;
+  if (dataURI.split(',')[0].indexOf('base64') >= 0)
+    byteString = atob(dataURI.split(',')[1]);
+  else
+    byteString = unescape(dataURI.split(',')[1]);
+
+  // separate out the mime component
+  var mimeString = dataURI.split(',')[0].split(':')[1].split(';')[0];
+
+  // write the bytes of the string to a typed array
+  var ia = new Uint8Array(byteString.length);
+  for (var i = 0; i < byteString.length; i++) {
+    ia[i] = byteString.charCodeAt(i);
+  }
+
+  return new Blob([ia], {type:mimeString});
+}
+
+
 function registerPVAChartEvents() {
   positionChart = new CanvasJS.Chart("positionGraph",{
       // // axisX:{

--- a/static/js/simulator/base.js
+++ b/static/js/simulator/base.js
@@ -47,8 +47,8 @@ function canvasToImage() {
   // draw background / rect on entire canvas
   context.fillRect(0, 0, w, h);
 
-  // get the image data from the canvas
-  var imageData = canvas.el.toDataURL("image/jpeg", 0.5);
+  // get the image data from the canvas and decrement image quality 70%
+  var imageData = canvas.el.toDataURL("image/jpeg", 0.3);
 
   // clear the canvas
   context.clearRect(0, 0, w, h);

--- a/views/dormant/home.html
+++ b/views/dormant/home.html
@@ -27,41 +27,7 @@
     </div>
   </div>
 
-  {{ if .Data.simulations }}
-    <div class="container pad-bottom">
-      <ul class="card-list">
-        {{ range $simulation := .Data.simulations }}
-          <li>
-            <div class="hide-on-small-only card-quarter-width card">
-              <div class="card-image waves-effect waves-block waves-dark">
-                <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}"><img class="responsive-img simulation-thumb" src="{{ $simulation.ImageSrcUrl }}" /></a>
-              </div>
-              <div class="card-content simulation-thumb-description">
-                <span class="card-title">
-                  <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}">{{ $simulation.Name }}</a>
-                </span>
-                <p><small>A {{ $simulation.Type }} simulation by <a href="/user/{{ $simulation.AuthorID }}">{{ $simulation.AuthorName }}</a></small></p>
-              </div>
-            </div>
-
-            <div class="hide-on-med-and-up card-half-width card">
-              <div class="card-image waves-effect waves-block waves-dark">
-                <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}"><img class="responsive-img simulation-thumb" src="{{ $simulation.ImageSrcUrl }}" /></a>
-              </div>
-              <div class="card-content simulation-thumb-description">
-                <span class="card-title">
-                  <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}">{{ $simulation.Name }}</a>
-                </span>
-                <p><small>A {{ $simulation.Type }} simulation by <a href="/user/{{ $simulation.AuthorID }}">{{ $simulation.AuthorName }}</a></small></p>
-              </div>
-            </div>
-          </li>
-        {{ end }}
-      </ul>
-    </div>
-
-    <div class="clear pad-bottom"></div>
-  {{ end }}
+  {{ template "simulationsListFrag" . }}
 
   {{ if not .IsLoggedIn }}
     <div class="container narrow pad-top pad-bottom">

--- a/views/dormant/home.html
+++ b/views/dormant/home.html
@@ -33,10 +33,10 @@
         {{ range $simulation := .Data.simulations }}
           <li>
             <div class="hide-on-small-only card-quarter-width card">
-              <div class="card-image waves-effect waves-block waves-light">
-                <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}"><img class="responsive-img" src="/static/img/accent.png" /></a>
+              <div class="card-image waves-effect waves-block waves-dark">
+                <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}"><img class="responsive-img simulation-thumb" src="{{ $simulation.ImageSrcUrl }}" /></a>
               </div>
-              <div class="card-content">
+              <div class="card-content simulation-thumb-description">
                 <span class="card-title">
                   <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}">{{ $simulation.Name }}</a>
                 </span>
@@ -45,10 +45,10 @@
             </div>
 
             <div class="hide-on-med-and-up card-half-width card">
-              <div class="card-image waves-effect waves-block waves-light">
-                <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}"><img class="responsive-img" src="/static/img/accent.png" /></a>
+              <div class="card-image waves-effect waves-block waves-dark">
+                <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}"><img class="responsive-img simulation-thumb" src="{{ $simulation.ImageSrcUrl }}" /></a>
               </div>
-              <div class="card-content">
+              <div class="card-content simulation-thumb-description">
                 <span class="card-title">
                   <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}">{{ $simulation.Name }}</a>
                 </span>

--- a/views/simulator/simList.frag.html
+++ b/views/simulator/simList.frag.html
@@ -6,10 +6,10 @@
       {{ range $simulation := .Data.simulations }}
         <li>
           <div class="hide-on-small-only card-quarter-width card">
-            <div class="card-image waves-effect waves-block waves-light">
-              <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}"><img class="responsive-img" src="/static/img/accent.png" /></a>
+            <div class="card-image waves-effect waves-block waves-dark">
+              <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}"><img class="responsive-img simulation-thumb" src="{{ $simulation.ImageSrcUrl }}" /></a>
             </div>
-            <div class="card-content">
+            <div class="card-content simulation-thumb-description">
               <span class="card-title">
                 <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}">{{ $simulation.Name }}</a>
               </span>
@@ -35,10 +35,10 @@
           </div>
 
           <div class="hide-on-med-and-up card-half-width card">
-            <div class="card-image waves-effect waves-block waves-light">
-              <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}"><img class="responsive-img" src="/static/img/accent.png" /></a>
+            <div class="card-image waves-effect waves-block waves-dark">
+              <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}"><img class="responsive-img simulation-thumb" src="{{ $simulation.ImageSrcUrl }}" /></a>
             </div>
-            <div class="card-content">
+            <div class="card-content simulation-thumb-description">
               <span class="card-title">
                 <a href="/simulator/{{ $simulation.Type }}/{{ $simulation.KeyName }}">{{ $simulation.Name }}</a>
               </span>

--- a/views/simulator/simList.frag.html
+++ b/views/simulator/simList.frag.html
@@ -3,7 +3,12 @@
 {{ if .Data.simulations }}
   <div class="container">
     <ul class="card-list">
-      {{ range $simulation := .Data.simulations }}
+      {{ range $idx, $simulation := .Data.simulations }}
+        {{ if evenlyDivisible $idx 4 }}
+          <li class="clear"></li>
+        {{ else if evenlyDivisible $idx 2 }}
+          <li class="hide-on-med-and-up clear"></li>
+        {{ end }}
         <li>
           <div class="hide-on-small-only card-quarter-width card">
             <div class="card-image waves-effect waves-block waves-dark">

--- a/views/simulator/simulator.frag.html
+++ b/views/simulator/simulator.frag.html
@@ -22,7 +22,7 @@
     </div>
     {{ end }}
     <div class="col s1 right pad-sides">
-      <h4><a class="waves-effect waves-light btn-floating green darken-1" id="save-button" onclick="saveSimulation()"><i class="fa fa-floppy-o"></i></a></h4>
+      <h4><a class="waves-effect waves-light btn-floating green darken-1" id="save-button" onclick="saveSimulation({{ .Data.imageUploadUrl }})"><i class="fa fa-floppy-o"></i></a></h4>
     </div>
     <!-- Private/Public Checkbox -->
     <div class="col s2 right private-checkbox">

--- a/views/user/profile.html
+++ b/views/user/profile.html
@@ -28,10 +28,15 @@
           <label>Email</label>
           <p class="pad-sides">{{ .Data.user.Email }}</p>
         </div>
-        {{ else }}
+        {{ else if .Data.user.DisplayName }}
         <div>
           <label>Display Name</label>
           <p class="pad-sides">{{ .Data.user.DisplayName }}</p>
+        </div>
+        {{ else }}
+        <div>
+          <label>Display Name</label>
+          <p class="pad-sides">Anonymous</p>
         </div>
         {{ end }}
         <div>
@@ -48,16 +53,24 @@
     <div class="col s6">
       <div class="card-panel">
         <div class="file-field">
-          <div id="profile-pic-container" class="valign-wrapper dark-accent-gradient-1">
-            <div class="valign center-align" style="width: 100%;">
-              <i class="white-text fa fa-user large"></i>
+          {{ if .Data.userProfileImageSrc }}
+            <div class="inherit-size">
+              <img class="responsive-img" src="{{ .Data.userProfileImageSrc }}">
             </div>
-          </div>
+          {{ else }}
+            <div class="inherit-size dark-accent-gradient-1 empty-profile-image-container">
+              <i class="inherit-size center-align white-text fa fa-user large"></i>
+            </div>
+          {{ end }}
           {{ if .Data.userIsOwner }}
-          <input type='file' onchange="readURL(this);" />
-          <div class="file-path-wrapper">
-            <input class="file-path validate" type="text" placeholder="Upload An Image">
-          </div>
+            <div class="file-path-wrapper">
+              <input id="user-profile-image" name="ProfileImage" type="file" onchange="validateUserImageSelection()">
+            </div>
+          {{ end }}
+          {{ if .Data.userIsOwner }}
+            <div class="center-align pad-top">
+              <a id="image-upload-message">Click to upload a new profile image!</a>
+            </div>
           {{ end }}
         </div>
       </div>
@@ -85,7 +98,7 @@
   {{ if .Data.userIsOwner }}
   <div class="row">
     <div class="center-align">
-      <a class="waves-effect waves-light btn-large blue darken-1" id="profile-save-button" onclick="saveUser()"><i class="fa fa-floppy-o"></i> Update!</a>
+      <a class="waves-effect waves-light btn-large blue darken-1" id="save-button" onclick="saveUser({{ .Data.imageUploadUrl }})"><i class="fa fa-floppy-o"></i> Update!</a>
     </div>
   </div>
   {{ end }}


### PR DESCRIPTION
Simulations now have thumbnail images generated and persisted with a simulation whenever you save. Also, users can now upload a profile image if they would like.

The Google App Engine Blobstore stuff seems a little wonky to me. We have to generate a specific google url to post against every time we post to the blobstore. This blobstore url generation happens on page load, so this means that we can't save a simulation asynchronously. We have to refresh the page every time to generate that new google url to post against for images.

Ironically, the cleanest way I found to generate images as blobs of a canvas element and then post using javascript has depreciated synchronous posting?! So I asynchronously post, then wait for the server to respond with the new route to redirect to, then use javascript to redirect there. Hmmmmm.

Fixes #95
Fixes #127
